### PR TITLE
Remove unnecessary dependencies, add versions to other packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,9 @@
     "test": "NODE_ENV='test' mocha --timeout 15000 -R list --bail"
   },
   "dependencies": {
-    "hiredis": "",
-    "redis": "",
-    "underscore": "",
-    "request": "",
-    "winston": ""
+    "underscore": "1.5.x",
+    "request": "2.27.x",
+    "winston": "0.7.x"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
Redis is no longer a necessary dependency.
Pin other dependencies to the latest major version numbers to
prevent the possibility of breaking changes when releasing in
production.
